### PR TITLE
portacle-update: don't try to remove used packages

### DIFF
--- a/portacle-update.el
+++ b/portacle-update.el
@@ -23,7 +23,8 @@
                 do (when (and in-archive
                               (version-list-< (get-version name package-alist) in-archive))
                      (package-install name)
-                     (push package-desc to-delete)))
+                     (unless (package--used-elsewhere-p package-desc)
+                       (push package-desc to-delete))))
        (mapcar #'package-delete to-delete)))))
 
 (defun portacle-update ()


### PR DESCRIPTION
Fixes the
```
package-delete: Package ‘async-20180527.1030’ is used by ‘with-editor’ as dependency, not deleting
```
error, mentioned in https://github.com/portacle/emacsd/pull/12 which caused the update to not end cleanly.